### PR TITLE
Shelters are ordered by name in reverse_alpha

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,5 @@
+class AdminController < ApplicationController
+  def index
+    @shelters = Shelter.reverse_alpha
+  end
+end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -16,6 +16,10 @@ class Shelter < ApplicationRecord
       .order("pets_count DESC")
   end
 
+  def self.reverse_alpha
+    order('name desc')
+  end
+
   def pet_count
     pets.count
   end
@@ -31,4 +35,5 @@ class Shelter < ApplicationRecord
   def shelter_pets_filtered_by_age(age_filter)
     adoptable_pets.where('age >= ?', age_filter)
   end
+
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,0 +1,5 @@
+<div class="shelters">
+  <% @shelters.each do |shelter| %>
+    <%= shelter.name %> <br>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
       <p><%= link_to "Shelters", "/shelters" %></p>
       <p><%= link_to "Veterinarians", "/veterinarians" %></p>
       <p><%= link_to "Veterinary Offices", "/veterinary_offices" %></p>
+      <p><%= link_to "Admin Shelters", "/admin/shelters" %></p>
     </section>
     <%= yield %>
   </body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   get '/applicants/:applicant_id', to: 'applicants#show'
   patch '/applicants/:applicant_id', to: 'applicants#show'
 
+  get '/admin/shelters', to: 'admin#index'
+
   get '/shelters', to: 'shelters#index'
   get '/shelters/new', to: 'shelters#new'
   get '/shelters/:id', to: 'shelters#show'

--- a/spec/features/admin/shelters/index_spec.rb
+++ b/spec/features/admin/shelters/index_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Shelter do
+  describe 'Admin Shelters' do
+    it 'lists all the shelters in reverse alpha by name' do
+      shelter1 = Shelter.create(name: 'RGV animal shelter', city: 'Harlingen, TX', foster_program: false, rank: 5)
+      shelter2 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
+      shelter3 = Shelter.create(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)
+
+      visit '/admin/shelters'
+      
+      within '.shelters' do
+        expect(shelter1.name).to appear_before(shelter3.name)
+        expect(shelter3.name).to appear_before(shelter2.name)
+        expect(shelter2.name).to_not appear_before(shelter1.name)
+      end
+    end
+  end
+end
+
+# @shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
+# @shelter_2 = Shelter.create(name: 'RGV animal shelter', city: 'Harlingen, TX', foster_program: false, rank: 5)
+# @shelter_3 = Shelter.create(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)
+# @shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
+# @shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
+# @shelter_3.pets.create(name: 'Lucille Bald', breed: 'sphynx', age: 8, adoptable: true)

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe Shelter, type: :model do
         expect(Shelter.order_by_number_of_pets).to eq([@shelter_1, @shelter_3, @shelter_2])
       end
     end
+
+    describe '#reverse_alpha' do
+      it 'sorts all shelters in reverse alpha order' do
+        expect(Shelter.reverse_alpha).to eq([@shelter_2, @shelter_3, @shelter_1])
+      end
+    end
   end
 
   describe 'instance methods' do


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):
## Problem/feature
_What problem are you trying to solve?_
- the /admin/shelter index page needed to be able to see all the shelters and order them in reverse alpha order
## Solution
_How did you solve the problem?_
- I was able to leverage sql and active record in the shelter model to create a method that orders the shelters in the necessary order
## Other changes (e.g. bug fixes, UI tweaks, small refactors)
- In the application.html.erb I added a link for the administration offices although currently there is no authentication for that link it takes 
## Checklist
- [x] Code compiles correctly
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary